### PR TITLE
fix(loop): load the published package name

### DIFF
--- a/loop/cordis.patch.yml
+++ b/loop/cordis.patch.yml
@@ -1,3 +1,3 @@
 - insert:
     - id: loop
-      name: 'loop'
+      name: 'dsh-loop'

--- a/loop/test/bundle-contract.test.ts
+++ b/loop/test/bundle-contract.test.ts
@@ -1,0 +1,12 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+describe('DSH bundle contract', () => {
+  it('loads the published package name from the bundle patch', async () => {
+    const manifest = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+    const patch = await readFile(new URL('../cordis.patch.yml', import.meta.url), 'utf8')
+
+    expect(manifest.name).toBe('dsh-loop')
+    expect(patch).toMatch(/^\s*name:\s*['"]?dsh-loop['"]?\s*$/m)
+  })
+})


### PR DESCRIPTION
## Summary

- load the published package name `dsh-loop` from the DSH Bundle Patch
- add a regression test that keeps the manifest and patch package names aligned

## Validation

- `pnpm exec vitest run test/bundle-contract.test.ts --maxWorkers=1`
- `pnpm typecheck`
- `pnpm typecheck:client`
- package build completed during the isolated install

## Existing upstream test issue

A frozen install currently reports that `loop/pnpm-lock.yaml` is out of date with `loop/package.json`. A non-frozen install resolves React 19 alongside React DOM 18, so the unrelated UI suite fails before collecting tests. This PR intentionally leaves that broader dependency update out of scope.