### PR TITLE
fix(mock): remove hardcoded author-machine absolute path from published cordis.patch.yml

### DIFF
--- a/mock/cordis.patch.yml
+++ b/mock/cordis.patch.yml
@@ -5,7 +5,5 @@
       name: '@deepseek-ai/dsh-host-directory-picker-browse'
     - id: ui-directory-picker-browse
       name: '@deepseek-ai/dsh-client-ui-directory-picker-browse'
-    - id: codex-shell
-      name: 'file:///C:/Users/yifan/code/Ephemeral-AI-Lab/dsh-plugins/codex-shell/lib/index.js'
     - id: mock
       name: 'dsh-mock'


### PR DESCRIPTION
## Summary

`dsh-mock@0.1.0` is not installable on any machine other than the author's. Its published `cordis.patch.yml` hardcodes a **local absolute path** to a codex-shell checkout:

```yaml
- id: codex-shell
  name: 'file:///C:/Users/yifan/code/Ephemeral-AI-Lab/dsh-plugins/codex-shell/lib/index.js'
```

Consequences (verified on an isolated DeepSeek Harness rc.7 profile):

1. **Standalone install fails to boot**: `dsh plugin add dsh-mock` then boot crashes with
   `ERR_MODULE_NOT_FOUND: Cannot find module 'C:\Users\yifan\code\Ephemeral-AI-Lab\...\lib\index.js'`.
2. **Coexistence with dsh-codex-shell crashes**: mock's patch also inserts the `codex-shell` entry id, while `dsh-codex-shell` inserts the same id from its own bundle → `duplicate loader entry id: codex-shell` at boot.

## Change

Remove that single row from `mock/cordis.patch.yml` (2 deletions). Mock no longer attempts to mount an external codex-shell from a machine-specific path.

## Verification (rc.7 isolated profile, full evidence captured)

- **mock alone** (profile bundles = base, web-app, dsh-mock; profile patch = probe only): boots, `fiberPhase: active`.
- **mock + codex-shell** (both bundles installed): boots, both `mock` and `codex-shell` rows `fiberPhase: active`, no duplicate-id crash.
- `--dump-config` shows one `mock` row, one `codex-shell` row, no duplicates.

## Note

This only makes the published artifact boot-clean. `dsh-mock` is still marked **unstable** in the README and its own `fix-to-do.md` records a FAIL review status — this PR is scoped to the release-blocking packaging bug, not an endorsement of mock's stability. A follow-up worth considering: add an isolated-boot smoke test to the publish pipeline (plug into a disposable DSH profile and assert the patch mounts), so regression like this is caught before npm publish.

## Tests

No runtime tests are affected (this is a packaging/manifest fix). A boot-smoke test would ideally be added separately (see Note).
